### PR TITLE
Don't force custom CSS on users who might not want it

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "files": ["dist", "src"],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepare": "cp src/github.meta.js dist; uglifyjs src/index.js src/github.js -o dist/github.js -e document:document -mc --inline-script && uglifyjs --comments all dist/github.meta.js dist/github.js -o dist/github.user.js"
+    "prepare": "cp src/github.meta.js dist; cp src/github.css dist/github.user.css; uglifyjs src/index.js src/github.js -o dist/github.js -e document:document -mc --inline-script && uglifyjs --comments all dist/github.meta.js dist/github.js -o dist/github.user.js"
   },
   "repository": {
     "type": "git",

--- a/src/github.css
+++ b/src/github.css
@@ -1,0 +1,32 @@
+/*
+The userstyle to specify the GitHub style as the author of this script intended
+
+Needs to be installed with Stylus/Stylish/any other userstyles manager
+
+# Stylus:
+- Firefox:	https://addons.mozilla.org/en-US/firefox/addon/styl-us/
+- Opera:	https://addons.opera.com/extensions/details/stylus/
+- Chrome:	https://chrome.google.com/webstore/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne
+
+# Stylish:
+- Firefox:	https://addons.mozilla.org/en-US/firefox/addon/stylish/
+- Opera:	https://addons.opera.com/en/extensions/details/stylish/
+- Chrome:	https://chrome.google.com/webstore/detail/stylish-custom-themes-for/fjnbnpbmkenffdnngjfgmeleoegfcffe
+*/
+@-moz-document domain("github.com") {
+	.blob-code,
+	.blob-code span {
+		font-family:	'InputSerifNarrow', 'Georgia', serif !important;
+		font-size:	1.167em !important;
+	}
+
+	.highlight .p {
+		color: #bbb;
+		font-weight: lighter;
+	}
+
+	.highlight span.tab-char + .open.p {
+		position: absolute;
+		transform: translateX(-100%);
+	}
+}

--- a/src/github.js
+++ b/src/github.js
@@ -1,10 +1,4 @@
-var etab = new ElasticTabstops({
-	styleRules: [
-		".blob-code { font-family: 'Input Serif Narrow', 'Georgia', serif; font-size: 1.167em; }",
-		".highlight .p { color: #bbb; font-weight: lighter; }",
-		".highlight span.tab-char + .open.p { position: absolute; transform: translateX(-100%); }",
-	]
-})
+var etab = new ElasticTabstops()
 
 function process() {
 	var openPuncs = /^["'([{“‘]+$/


### PR DESCRIPTION
Moves the custom CSS into `github.user.css` to be loaded by [Stylus](https://addons.mozilla.org/en-US/firefox/addon/styl-us/) or [Stylish](https://addons.mozilla.org/en-US/firefox/addon/stylish/).
This makes it an optional feature rather than something that users are forced to use.

---

Split off from #2